### PR TITLE
feat: calender highlight logics

### DIFF
--- a/src/components/calender/Calender.tsx
+++ b/src/components/calender/Calender.tsx
@@ -5,6 +5,7 @@ import { getMonth, add, getDay, getYear } from "date-fns";
 import { DayState } from "../../store/global";
 import { useRecoilState } from "recoil";
 import { months, daysShort } from "../../static/constant/calenderValues";
+import CalenderHeader from "./CalenderHeader";
 
 import Table from "./Table";
 export const Calender = () => {
@@ -21,19 +22,16 @@ export const Calender = () => {
       <button type="button" onClick={() => setToday(add(today, { months: 1 }))}>
         다음달
       </button>
-      <button>
-        {getYear(today)} {months[getMonth(today)]}
+      <button type="button" onClick={() => setToday(new Date())}>
+        이번달
       </button>
 
       <div className="text-center mx-auto w-full">
-        <div className="flex w-full mx-auto justify-center gap-7">
-          {daysShort.map((day, i) => (
-            <div key={uid(i)}>
-              <div>{day}</div>
-            </div>
-          ))}
-        </div>
-        <Table />
+        <CalenderHeader today={today} />
+        <Table today={today} />
+
+        <CalenderHeader today={add(today, { months: 1 })} />
+        <Table today={add(today, { months: 1 })} />
       </div>
     </div>
   );

--- a/src/components/calender/CalenderHeader.tsx
+++ b/src/components/calender/CalenderHeader.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { getMonth, add, getDay, getYear } from "date-fns";
+import { months, daysShort } from "../../static/constant/calenderValues";
+import { DayState } from "../../store/global";
+import { useRecoilState } from "recoil";
+import { uid } from "react-uid";
+
+type TableType = {
+  today: Date;
+};
+
+const CalenderHeader = (props: TableType) => {
+  return (
+    <>
+      <button>
+        {getYear(props.today)} {months[getMonth(props.today)]}
+      </button>
+
+      <div className="text-center mx-auto w-full">
+        <div className="flex w-full mx-auto justify-center gap-7">
+          {daysShort.map((day, i) => (
+            <div key={uid(i)}>
+              <div>{day}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CalenderHeader;

--- a/src/components/calender/Cell.tsx
+++ b/src/components/calender/Cell.tsx
@@ -1,32 +1,73 @@
 import React from "react";
-import { DayState } from "../../store/global";
+import { DayState, pickDateState } from "../../store/global";
 import { useRecoilState, useRecoilValue } from "recoil";
-import { setDate, format, getDay } from "date-fns";
+import { setDate, format, getDay, isBefore, isSameMonth } from "date-fns";
+import tw from "tailwind-styled-components";
+import { useHighlightDate } from "../../hooks/useHighlightDate";
 type CellType = {
   value: Date | number;
+  month: Date;
 };
+
+interface Cells {
+  thisdate: Date;
+  startpicked: Date;
+  endpicked: Date;
+  highlights: number;
+  issame: number;
+}
 
 const Cell = (props: CellType) => {
   // console.log(props.value);
+  const [pick, setPick] = useRecoilState(pickDateState);
+  const { dateFilter } = useHighlightDate();
+  // console.log(dateFilter(props.value));
+
   const fixedToday = format(new Date(), "yyyy-MM-dd");
   const date = format(props.value, "d");
-  console.log(fixedToday);
-  // const day = setDate(date, props.value);
-
+  const dateHighlights = () => {
+    if (pick.startDate === null) {
+      if (isBefore(props.value, new Date())) {
+        alert("뒤에 날짜는 선택할수 없음");
+        return;
+      }
+      setPick({ startDate: props.value, endDate: null });
+    } else if (pick.startDate !== null && pick.endDate === null) {
+      if (isBefore(props.value, pick.startDate)) {
+        alert("뒤에 날짜는 선택할수 없음");
+        return;
+      }
+      setPick({ startDate: pick.startDate, endDate: props.value });
+    } else if (pick.startDate !== null && pick.endDate !== null) {
+      setPick({ startDate: null, endDate: null });
+    }
+  };
   return (
     <>
-      <div
+      <EachCell
         className={
           fixedToday === format(props.value, "yyyy-MM-dd")
             ? "w-14 h-14 cursor-pointer bg-blue-400"
             : "w-14 h-14 cursor-pointer"
         }
-        onClick={() => console.log(props.value)}
+        thisdate={props.value}
+        highlights={dateFilter(props.value) ? 1 : 0}
+        startpicked={pick.startDate}
+        endpicked={pick.endDate}
+        issame={isSameMonth(props.value, props.month) ? 1 : 0}
+        onClick={() => dateHighlights()}
       >
         {date}
-      </div>
+      </EachCell>
     </>
   );
 };
 
 export default Cell;
+
+const EachCell = tw.div<Cells>`
+${(props: Cells) => props.startpicked === props.thisdate && "bg-indigo-600"}
+  ${(props: Cells) => props.endpicked === props.thisdate && "bg-indigo-600"}
+    ${(props: Cells) => props.highlights === 1 && "bg-indigo-500"}
+    ${(props: Cells) => props.issame === 0 && "text-gray-400"}
+`;

--- a/src/components/calender/Cell.tsx
+++ b/src/components/calender/Cell.tsx
@@ -15,6 +15,7 @@ interface Cells {
   endpicked: Date;
   highlights: number;
   issame: number;
+  isbefore: number;
 }
 
 const Cell = (props: CellType) => {
@@ -55,6 +56,7 @@ const Cell = (props: CellType) => {
         startpicked={pick.startDate}
         endpicked={pick.endDate}
         issame={isSameMonth(props.value, props.month) ? 1 : 0}
+        isbefore={isBefore(props.value, new Date()) ? 1 : 0}
         onClick={() => dateHighlights()}
       >
         {date}
@@ -70,4 +72,5 @@ ${(props: Cells) => props.startpicked === props.thisdate && "bg-indigo-600"}
   ${(props: Cells) => props.endpicked === props.thisdate && "bg-indigo-600"}
     ${(props: Cells) => props.highlights === 1 && "bg-indigo-500"}
     ${(props: Cells) => props.issame === 0 && "text-gray-400"}
+    ${(props: Cells) => props.isbefore === 1 && "text-gray-400"}
 `;

--- a/src/components/calender/Table.tsx
+++ b/src/components/calender/Table.tsx
@@ -4,18 +4,20 @@ import { generateCalendar } from "../../hooks/getMonth";
 import { DayState } from "../../store/global";
 import { useRecoilState } from "recoil";
 import Cell from "./Cell";
-// type TableType = {
-//   className: string;
-// };
 
-const Table = () => {
-  const [today, setToday] = useRecoilState(DayState);
+type TableType = {
+  today: Date;
+};
+
+const Table = (props: TableType) => {
+  // const [today, setToday] = useRecoilState(DayState);
+
   return (
     <>
-      {generateCalendar(today).map((date, i) => (
+      {generateCalendar(props.today).map((date, i) => (
         <div key={i} className="flex justify-center items-center">
           {date.map((day, i) => {
-            return <Cell key={uid(i)} value={day} />;
+            return <Cell key={uid(i)} value={day} month={props.today} />;
           })}
         </div>
       ))}

--- a/src/hooks/useHighlightDate.tsx
+++ b/src/hooks/useHighlightDate.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { useRecoilState, useRecoilValue } from "recoil";
+import { pickDateState } from "../store/global";
+import { eachDayOfInterval, isSameDay } from "date-fns";
+
+export const useHighlightDate = () => {
+  const pick = useRecoilValue(pickDateState);
+  // console.log(pick.startDate);
+  const dd: any =
+    pick.startDate !== null && pick.endDate !== null
+      ? eachDayOfInterval({ start: pick.startDate, end: pick.endDate })
+      : "";
+
+  const dateFilter = (date: any) => {
+    let a = false;
+    if (dd) {
+      for (let i = 0; i < dd.length; i++) {
+        if (isSameDay(dd[i], date)) {
+          a = true;
+          break;
+        }
+      }
+      return a;
+    }
+  };
+  return { dd, dateFilter };
+};

--- a/src/store/global.ts
+++ b/src/store/global.ts
@@ -5,15 +5,15 @@ export const DayState = atom({
   default: new Date(),
 });
 
-export const weekdayArray = atom({
-  key: "weekdayArray",
-  default: [""],
+export const dateArray = atom<Date[]>({
+  key: "dateArray",
+  default: [],
 });
 
-export const timeState = atom({
-  key: "timeState",
+export const pickDateState = atom<any>({
+  key: "pickDateState",
   default: {
-    time: 0,
-    startTime: 0,
+    startDate: null,
+    endDate: null,
   },
 });


### PR DESCRIPTION
## 작업내역
- 캘린더 하이라이트 적용
  - 오늘날짜보다 뒤면 클릭안되게
  - 시작날짜보다 끝날짜가 뒤면 클릭안되게
  - 다음달까지 연결해서 클릭 가능
  - 한번 클릭시 시작날짜 두번 클릭시 끝날짜 세번째는 클릭취소
 
- 캘린더 css 
  - 날짜가 이번달이 아닌게 있다면 글씨를 회색으로 보여줌
  - 오늘 날짜에 하이라이트 기본설정
 
 ## 작업파일
 - grobal.ts