### PR TITLE
fix: virtual scroll의 윗부분의  empty box 이슈 해결

### DIFF
--- a/src/common/Card.tsx
+++ b/src/common/Card.tsx
@@ -13,10 +13,10 @@ const Card = ({ item }: { item: Hotel }) => {
         className="w-full bg-red-300"
         style={{
           height: "300px",
-          padding: "10px",
+          margin: "10px",
         }}
       >
-        {JSON.stringify(item)}
+        {JSON.stringify(item.hotel_name)}
       </div>
     </>
   );

--- a/src/common/VirtualScroll.tsx
+++ b/src/common/VirtualScroll.tsx
@@ -35,7 +35,7 @@ const VirtualScroll = ({
   // issue: 스크롤 내린 다음 새로고침 시 y축이 살아있어 empty box 생성
   // TODO: => scroll to top시키거나 scroll restoration(얘는 이슈 해결 못할 수 있음) 하기
 
-  const containerHeight = (itemHeight + columnGap) * itemCount + columnGap * 2;
+  const containerHeight = (itemHeight + columnGap) * itemCount;
 
   const startIndex = Math.max(
     Math.floor(offsetY / (itemHeight + columnGap)) - renderAhead,

--- a/src/common/VirtualScroll.tsx
+++ b/src/common/VirtualScroll.tsx
@@ -31,11 +31,7 @@ const VirtualScroll = ({
     setViewportY(viewportY);
   }, []);
 
-  // console.log(y, offsetY);
-  // issue: 스크롤 내린 다음 새로고침 시 y축이 살아있어 empty box 생성
-  // TODO: => scroll to top시키거나 scroll restoration(얘는 이슈 해결 못할 수 있음) 하기
-
-  const containerHeight = (itemHeight + columnGap) * itemCount + columnGap * 2;
+  const containerHeight = (itemHeight + columnGap) * itemCount;
 
   const startIndex = Math.max(
     Math.floor(offsetY / (itemHeight + columnGap)) - renderAhead,

--- a/src/common/VirtualScroll.tsx
+++ b/src/common/VirtualScroll.tsx
@@ -1,38 +1,49 @@
-import React, { ReactNode, useState } from "react";
+import React from "react";
 import { useWindowScroll, useWindowSize } from "react-use";
 
 type Props = {
   Item: React.ElementType;
-  itemList: Array<object>; // TODO: Array<object>말고도 다르게 type 지정하는 방법 고민
+  itemList: Array<object>;
+  itemCount: number;
   itemHeight: number;
   rowGap?: number;
   columnGap?: number;
   renderAhead?: number;
 };
 
-// TODO: Padding 추가
 const VirtualScroll = ({
   Item,
   itemList,
+  itemCount,
   itemHeight,
   rowGap = 0,
   columnGap = 0,
-  renderAhead = 1,
+  renderAhead = 0,
 }: Props) => {
-  const itemCount = itemList.length;
-
-  const { width, height } = useWindowSize();
+  const { height } = useWindowSize();
   const { y } = useWindowScroll();
 
-  const containerHeight = (itemHeight + columnGap) * itemCount - columnGap;
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+  const [viewportY, setViewportY] = React.useState<number>(0);
+  const offsetY = y - viewportY;
+  React.useEffect(() => {
+    const viewportY = scrollRef.current?.getBoundingClientRect().y ?? 0;
+    setViewportY(viewportY);
+  }, []);
+
+  // console.log(y, offsetY);
+  // issue: 스크롤 내린 다음 새로고침 시 y축이 살아있어 empty box 생성
+  // TODO: => scroll to top시키거나 scroll restoration(얘는 이슈 해결 못할 수 있음) 하기
+
+  const containerHeight = (itemHeight + columnGap) * itemCount + columnGap * 2;
 
   const startIndex = Math.max(
-    Math.floor(y / (itemHeight + columnGap)) - renderAhead,
+    Math.floor(offsetY / (itemHeight + columnGap)) - renderAhead,
     0
   );
 
   const endIndex = Math.min(
-    Math.floor(height / itemHeight + startIndex) + renderAhead,
+    Math.ceil(height / (itemHeight + columnGap) + startIndex) + renderAhead,
     itemCount
   );
 
@@ -49,6 +60,7 @@ const VirtualScroll = ({
       style={{
         height: `${containerHeight}px`,
       }}
+      ref={scrollRef}
     >
       <div style={{ transform: `translateY(${translateY}px)` }}>
         {visibleItem.map((item, index) => (

--- a/src/page/Result.tsx
+++ b/src/page/Result.tsx
@@ -333,6 +333,7 @@ const Result = () => {
       <VirtualScroll
         Item={Card}
         itemList={DUMMY_DATA} // fetch한 length로 변경할 예정
+        itemCount={DUMMY_DATA.length}
         itemHeight={300}
         columnGap={10}
       />

--- a/src/page/Result.tsx
+++ b/src/page/Result.tsx
@@ -332,7 +332,7 @@ const Result = () => {
       <div>검색 결과 페이지</div>
       <VirtualScroll
         Item={Card}
-        itemList={DUMMY_DATA} // fetch한 length로 변경할 예정
+        itemList={DUMMY_DATA} // fetch한 data로 변경할 예정
         itemCount={DUMMY_DATA.length}
         itemHeight={300}
         columnGap={10}

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -1,23 +1,43 @@
-import React from "react";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import React, { useLayoutEffect } from "react";
+import {
+  BrowserRouter,
+  LayoutRouteProps,
+  Route,
+  Routes,
+  RoutesProps,
+  useLocation,
+} from "react-router-dom";
 import Home from "../page/Home";
 import Result from "../page/Result";
 import BookedList from "../page/BookedList";
 import { RecoilRoot } from "recoil";
 import Calender from "page/Calendar";
 
+// TODO: children type 지정
+const ScrollToTop = ({ children }: any) => {
+  const location = useLocation();
+
+  useLayoutEffect(() => {
+    document.documentElement.scrollTo(0, 0);
+  }, [location.pathname]);
+
+  return children;
+};
+
 const Router = () => {
   return (
     <BrowserRouter>
       <RecoilRoot>
-        <Routes>
-          {["/", "/home", "*"].map((path) => {
-            return <Route path={path} element={<Home />} key={path} />;
-          })}
-          <Route path="/result" element={<Result />} />
-          <Route path="/booked" element={<BookedList />} />
-          <Route path="/cal" element={<Calender />} />
-        </Routes>
+        <ScrollToTop>
+          <Routes>
+            {["/", "/home", "*"].map((path) => {
+              return <Route path={path} element={<Home />} key={path} />;
+            })}
+            <Route path="/result" element={<Result />} />
+            <Route path="/booked" element={<BookedList />} />
+            <Route path="/cal" element={<Calender />} />
+          </Routes>
+        </ScrollToTop>
       </RecoilRoot>
     </BrowserRouter>
   );


### PR DESCRIPTION
## 작업 내역

![제목 없음](https://user-images.githubusercontent.com/69149030/182258757-fc38934b-eec1-4840-956c-df576b8705e8.png)

virtual scroll에서 아이템 list의 윗 부분이 empty되는 이슈가 있었다.
위 사진을 보면 스크롤 시 빨간 박스만큼 empty되어있었다.

해당 이슈는 아이템 list의 offsetY가 아닌 브라우저 y를 startIndex의 기준으로 잡아서 발생한 이슈였다.
offsetY를 구함으로써 해당 이슈를 해결하였다.


## 보완사항
- 현재 스크롤 내린 다음 새로고침 시 y값이 0이 아니라서 empty box 생성한다
- scroll to top시켜 해당 이슈를 해결할 예정이다.