### PR TITLE
fix: 카드 높이가 고정되지 않아 무한스크롤이 잘 안되는 이슈 해결

### DIFF
--- a/src/common/Card.tsx
+++ b/src/common/Card.tsx
@@ -29,9 +29,9 @@ const Card = ({ data, isBooked }: PropsType) => {
   return (
     <div
       key={hotelName}
-      className="flex justify-between w-full mb-5 bg-white rounded-lg max-w-7xl  border-slate-300 drop-shadow-md "
+      className="flex justify-between w-full h-80 bg-white mt-5 mb-5 rounded-lg max-w-7xl  border-slate-300 drop-shadow-md "
     >
-      <div className="w-1/3">
+      <div className="w-1/3 h-full">
         <img
           src={IMAGE_URL}
           alt="hotel_image"

--- a/src/components/HotelList.tsx
+++ b/src/components/HotelList.tsx
@@ -47,7 +47,7 @@ const HotelList = () => {
       )}
       {isLoading || (
         <>
-          <VirtualScroll itemHeight={20} columnGap={0.625} renderAhead={10}>
+          <VirtualScroll itemHeight={20} columnGap={1.25} renderAhead={10}>
             {hotelList.map((hotel: Hotel, index: number) => (
               <Card key={uid(index)} data={hotel} isBooked={false} />
             ))}

--- a/src/components/bookedList/BookedMobile.tsx
+++ b/src/components/bookedList/BookedMobile.tsx
@@ -54,7 +54,7 @@ const BookedMobileContent = ({ hotel, isLoading }: Props) => {
     <>
       {!!hotel.length && (
         <div className="flex items-center justify-center w-full py-2 bg-white">
-          <VirtualScroll itemHeight={20} columnGap={0.625} renderAhead={5}>
+          <VirtualScroll itemHeight={20} columnGap={1.25} renderAhead={5}>
             {hotel.map((hotel, index) => (
               <Card key={uid(index)} data={hotel} isBooked={true} />
             ))}

--- a/src/components/bookedList/BookedWeb.tsx
+++ b/src/components/bookedList/BookedWeb.tsx
@@ -47,7 +47,7 @@ const BookedWebContent = ({ hotel, isLoading }: Props) => {
     <>
       {!!hotel.length && (
         <div className="flex items-center justify-center w-full py-2 ml-4 bg-white">
-          <VirtualScroll itemHeight={20} columnGap={0.625} renderAhead={5}>
+          <VirtualScroll itemHeight={20} columnGap={1.25} renderAhead={5}>
             {hotel.map((hotel, index) => (
               <Card key={uid(index)} data={hotel} isBooked={true} />
             ))}

--- a/src/components/result/ResultList.tsx
+++ b/src/components/result/ResultList.tsx
@@ -90,7 +90,7 @@ const ResultListContent = ({
       )}
       {searchList.length > 0 && (
         <>
-          <VirtualScroll itemHeight={20} columnGap={0.625} renderAhead={10}>
+          <VirtualScroll itemHeight={20} columnGap={1.25} renderAhead={10}>
             {searchList.map((result: Hotel) => {
               return (
                 <div key={result.hotel_name} className="w-full">

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -7,13 +7,6 @@ import NotFound404 from "../page/NotFound404";
 import About from "../page/About";
 
 const Router = () => {
-  const { pathname } = useLocation();
-  window.history.scrollRestoration = "manual";
-
-  React.useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [pathname]);
-
   return (
     <Routes>
       {["/", "/home"].map((path) => {


### PR DESCRIPTION
## 작업내역

- 카드 높이를 20rem으로 고정
- scroll to top 제거 (당시 virtual scroll에서 계산을 잘못해주었거나 카드 높이가 고정이 안 되어서 이슈가 난듯 함)

## 추가 작업

스크롤 복원작업